### PR TITLE
Add golangci-lint to CI and tag-based docker builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -98,6 +98,7 @@ steps:
         - failure
 
 # ── Docker Build ──────────────────────────────────────────────────────────────
+# Only runs on push to main or v* tags.
 
   - name: discord-build-start
     image: curlimages/curl:8.7.1
@@ -108,6 +109,12 @@ steps:
     commands:
       - |
         curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "{\"embeds\":[{\"title\":\"$DRONE_REPO - $DRONE_SOURCE_BRANCH - Build Started!\",\"url\":\"$DRONE_BUILD_LINK\"}]}"
+    when:
+      branch:
+        - main
+      event:
+        - push
+        - tag
 
   - name: build
     image: plugins/docker
@@ -132,15 +139,28 @@ steps:
         from_secret: dockerhub_username
       password:
         from_secret: dockerhub_token
-      auto_tag: true
-      auto_tag_aliases:
+      tags:
         - latest
     when:
-      ref:
-        - refs/heads/main
-        - refs/tags/**
+      branch:
+        - main
       event:
         - push
+
+  - name: build-push-release
+    image: plugins/docker
+    settings:
+      repo: th0rn0/lanops-discord-bot
+      dockerfile: resources/docker/Dockerfile
+      username:
+        from_secret: dockerhub_username
+      password:
+        from_secret: dockerhub_token
+      tags:
+        - latest
+        - ${DRONE_TAG}
+    when:
+      event:
         - tag
 
   - name: discord-build-success
@@ -153,6 +173,11 @@ steps:
       - |
         curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "{\"embeds\":[{\"title\":\"$DRONE_REPO - $DRONE_SOURCE_BRANCH - Build Success!\",\"url\":\"$DRONE_BUILD_LINK\"}]}"
     when:
+      branch:
+        - main
+      event:
+        - push
+        - tag
       status:
         - success
 
@@ -166,5 +191,10 @@ steps:
       - |
         curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "{\"embeds\":[{\"title\":\"$DRONE_REPO - $DRONE_SOURCE_BRANCH - Build Failure!\",\"url\":\"$DRONE_BUILD_LINK\"}]}"
     when:
+      branch:
+        - main
+      event:
+        - push
+        - tag
       status:
         - failure

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,6 +10,50 @@ trigger:
 
 steps:
 
+# ── Lint ──────────────────────────────────────────────────────────────────────
+
+  - name: discord-lint-start
+    image: curlimages/curl:8.7.1
+    failure: ignore
+    environment:
+      DISCORD_WEBHOOK_URL:
+        from_secret: discord_webhook_url
+    commands:
+      - |
+        curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "{\"embeds\":[{\"title\":\"$DRONE_REPO - $DRONE_SOURCE_BRANCH - Lint Started!\",\"url\":\"$DRONE_BUILD_LINK\"}]}"
+
+  - name: lint
+    image: golang:1.24
+    commands:
+      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+      - cd /drone/src/src && go mod download && golangci-lint run --timeout=10m ./...
+
+  - name: discord-lint-success
+    image: curlimages/curl:8.7.1
+    failure: ignore
+    environment:
+      DISCORD_WEBHOOK_URL:
+        from_secret: discord_webhook_url
+    commands:
+      - |
+        curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "{\"embeds\":[{\"title\":\"$DRONE_REPO - $DRONE_SOURCE_BRANCH - Lint Success!\",\"url\":\"$DRONE_BUILD_LINK\"}]}"
+    when:
+      status:
+        - success
+
+  - name: discord-lint-failure
+    image: curlimages/curl:8.7.1
+    failure: ignore
+    environment:
+      DISCORD_WEBHOOK_URL:
+        from_secret: discord_webhook_url
+    commands:
+      - |
+        curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "{\"embeds\":[{\"title\":\"$DRONE_REPO - $DRONE_SOURCE_BRANCH - Lint Failure!\",\"url\":\"$DRONE_BUILD_LINK\"}]}"
+    when:
+      status:
+        - failure
+
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
   - name: discord-test-start

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,0 +1,16 @@
+linters:
+  disable-all: true
+  enable:
+    - govet
+    - ineffassign
+    - unused
+    - misspell
+    - gofmt
+
+linters-settings:
+  gofmt:
+    simplify: true
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/src/cmd/discord-bot/main.go
+++ b/src/cmd/discord-bot/main.go
@@ -21,7 +21,6 @@ var (
 	logger zerolog.Logger
 	cfg    config.Config
 	msgCh  = make(chan channels.MsgCh, 20)
-	db     *gorm.DB
 )
 
 func main() {

--- a/src/internal/bot/handlers/eightball/eightball.go
+++ b/src/internal/bot/handlers/eightball/eightball.go
@@ -29,7 +29,7 @@ func Handler(s *discordgo.Session, m *discordgo.MessageCreate, commandParts []st
 		data, err := json.Marshal(payload)
 		if err != nil {
 			msgCh <- channels.MsgCh{Err: err, Message: "Something went wrong", Level: "ERROR"}
-			returnString = "There was a error connecting to the API"
+			s.ChannelMessageSend(m.ChannelID, "There was a error connecting to the API")
 			return
 		} else {
 			resp, err := http.Post(
@@ -39,7 +39,7 @@ func Handler(s *discordgo.Session, m *discordgo.MessageCreate, commandParts []st
 			)
 			if err != nil {
 				msgCh <- channels.MsgCh{Err: err, Message: "Something went wrong", Level: "ERROR"}
-				returnString = "There was a error connecting to the API"
+				s.ChannelMessageSend(m.ChannelID, "There was a error connecting to the API")
 				return
 			}
 			defer resp.Body.Close()

--- a/src/manager/events.go
+++ b/src/manager/events.go
@@ -58,8 +58,11 @@ func (a API) GetUpcomingEvents() ([]Event, error) {
 		return upcomingEvents, errors.New(errorMessage)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
-	err = json.Unmarshal(body, &upcomingEvents)
 	if err != nil {
+		logger.Error().Err(err).Msg("Cannot Read Response Body")
+		return upcomingEvents, err
+	}
+	if err := json.Unmarshal(body, &upcomingEvents); err != nil {
 		logger.Error().Err(err).Msg("Cannot Marshal JSON from Response")
 		return upcomingEvents, err
 	}
@@ -82,8 +85,11 @@ func getNextEvent(url string) (Event, error) {
 		return nextEvent, errors.New(errorMessage)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
-	err = json.Unmarshal(body, &nextEvent)
 	if err != nil {
+		logger.Error().Err(err).Msg("Cannot Read Response Body")
+		return nextEvent, err
+	}
+	if err := json.Unmarshal(body, &nextEvent); err != nil {
 		logger.Error().Err(err).Msg("Cannot Marshal JSON from Response")
 		return nextEvent, err
 	}


### PR DESCRIPTION
## Summary
- Add golangci-lint step to the CI pipeline
- Fix lint errors flagged by golangci-lint (unused var, ineffectual assignments)
- Split docker build into main (`latest`) and tag (`latest` + `\${DRONE_TAG}`) variants

## Test plan
- [ ] CI lint step passes
- [ ] CI test step passes
- [ ] Docker build runs on push to main
- [ ] Docker build-push-release runs on tag push and produces both `latest` and tag-named images

🤖 Generated with [Claude Code](https://claude.com/claude-code)